### PR TITLE
Set up codecov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,10 @@ jobs:
           python -m pip install tox tox-gh-actions
       - name: Test with pytest
         run: tox
+      - name: Upload coverage to Codecov
+        run: tox -e coverage,codecov
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
 
   lint-and-style:
     name: Lint and style check the source code with pre-commit hooks


### PR DESCRIPTION
Add coverage report preparation and upload to codecov to github actions (it was already in tox).

## TODO

- [ ] Need to set up codecov token and save it in the secrets for this repo (as `CODECOV_TOKEN`). @Benjamin-Lee can you do this?