### PR TITLE
fix isort and black interaction on imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ docs = [
 
 [tool.isort]
 known_third_party = ["hypothesis", "minimal"]
+multi_line_output = 3
+include_trailing_comma = true
+line_length = 88


### PR DESCRIPTION
as reported by @vaastav, isort and black were formatting imports in a conflicting manner. This makes isort follow the same rules as black (as per https://github.com/timothycrosley/isort/issues/694#issuecomment-473063700)