### PR TITLE
Update fastq strategy

### DIFF
--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -11,6 +11,9 @@ from hypothesis.strategies import characters, composite, integers, sampled_from,
 from .utilities import ambiguous_start_codons, ambiguous_stop_codons, protein_1to3
 
 
+MAX_ASCII = 126
+
+
 @composite
 def dna(
     draw: Callable,
@@ -176,20 +179,38 @@ def fasta(draw) -> str:
 
 
 @composite
-def fastq_quality(draw: Callable, size=0) -> str:
+def fastq_quality(
+    draw: Callable, size=0, min_score: int = 0, max_score: int = 62, offset: int = 64
+) -> str:
     """Generates the quality string for the FASTQ format
 
     Arguments:
     - `size`: Size of the quality string to be generated
+    - `min_score`: Lowest quality (PHRED) score to use.
+    - `max_score`: Highest quality (PHRED) score to use.
+    - `offset`: ASCII encoding offset. See https://en.wikipedia.org/wiki/FASTQ_format#Encoding
+    for more details.
 
     Note:
     According to https://en.wikipedia.org/wiki/FASTQ_format,
     the range of characters for the quality string ranges from
     byte value 0x21 to 0x7E.
     """
+    min_codepoint = min_score + offset
+    max_codepoint = max_score + offset
+
+    if max_codepoint > MAX_ASCII:
+        raise ValueError(
+            "{} is larger than the maximum ASCII value {}".format(
+                max_codepoint, MAX_ASCII
+            )
+        )
+
     return draw(
         text(
-            alphabet=characters(min_codepoint=64, max_codepoint=126),
+            alphabet=characters(
+                min_codepoint=min_codepoint, max_codepoint=max_codepoint
+            ),
             min_size=size,
             max_size=size,
         )
@@ -197,23 +218,14 @@ def fastq_quality(draw: Callable, size=0) -> str:
 
 
 @composite
-def fastq(draw: Callable, fasta_source=Dict[str, str]) -> str:
+def fastq(draw: Callable) -> str:
     """Generate strings representing sequences in FASTQ format.
     """
-    if fasta_source is None:
-        fasta_source = parsed_fasta()
+    header = ""
+    sequence = draw(dna())
+    description = ""
+    quality = draw(fastq_quality(size=len(sequence)))
 
-    fasta_sequence = draw(fasta_source)
-    # TODO: randomly wrap the quality string
-    quality_string = draw(fastq_quality(size=len(fasta_sequence["sequence"])))
-    return (
-        "@"
-        + fasta_sequence["comment"]
-        + "\n"
-        + fasta_sequence["sequence"]
-        + "\n+"
-        # original FASTQ format duplicated the comment (now usually omitted for space)
-        + draw(sampled_from(["", fasta_sequence["comment"]]))
-        + "\n"
-        + quality_string
+    return "@{header}\n{sequence}\n+{description}\n{quality}".format(
+        header=header, sequence=sequence, description=description, quality=quality
     )

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -189,7 +189,7 @@ def fastq_quality(draw: Callable, size=0) -> str:
     """
     return draw(
         text(
-            alphabet=characters(min_codepoint=33, max_codepoint=126),
+            alphabet=characters(min_codepoint=64, max_codepoint=126),
             min_size=size,
             max_size=size,
         )

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -242,8 +242,8 @@ def fastq(
     min_score: int = 0,
     max_score: int = 62,
     offset: int = 64,
-    add_comment: bool = False,
-    additional_description: bool = False,
+    add_comment: bool = True,
+    additional_description: bool = True,
 ) -> str:
     """Generate strings representing sequences in FASTQ format.
 

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -183,7 +183,7 @@ def sequence_id(
     """Generates a sequence ID.
 
     Arguments:
-    - `blacklist_character`: Characters to not include in the sequence ID.
+    - `blacklist_characters`: Characters to not include in the sequence ID.
     - `max_size`: Maximum length of the sequence ID.
     """
     return draw(
@@ -209,7 +209,6 @@ def fastq_quality(
     - `min_score`: Lowest quality (PHRED) score to use.
     - `max_score`: Highest quality (PHRED) score to use.
     - `offset`: ASCII encoding offset.
-    for more details.
 
     Note:
         See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/ for more details on
@@ -254,8 +253,7 @@ def fastq(
     - `max_score`: Highest quality (PHRED) score to use.
     - `offset`: ASCII encoding offset for quality string.
     - `add_comment`: Add a comment string after the sequence ID, separated by a space.
-    - `additional_description`: Add sequence ID and comment after `+` on thrid line.
-    for more details.
+    - `additional_description`: Add sequence ID and comment after `+` on third line.
 
     Note:
         See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/ for more details on

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -191,7 +191,7 @@ def sequence_id(
             alphabet=characters(
                 blacklist_characters=blacklist_characters,
                 min_codepoint=33,
-                max_codepoint=126,
+                max_codepoint=MAX_ASCII,
             ),
             max_size=max_size,
         )

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -211,7 +211,7 @@ def fastq_quality(
     - `offset`: ASCII encoding offset.
 
     Note:
-        See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/ for more details on
+        See <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/> for more details on
         the quality score encoding.
     """
     min_codepoint = min_score + offset
@@ -256,7 +256,7 @@ def fastq(
     - `additional_description`: Add sequence ID and comment after `+` on third line.
 
     Note:
-        See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/ for more details on
+        See <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/> for more details on
         the FASTQ format (and its quality score encoding).
     """
     seq_id = draw(sequence_id())

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -238,7 +238,13 @@ def fastq_quality(
 
 @composite
 def fastq(
-    draw, size=0, min_score: int = 0, max_score: int = 62, offset: int = 64
+    draw,
+    size=0,
+    min_score: int = 0,
+    max_score: int = 62,
+    offset: int = 64,
+    add_comment: bool = False,
+    additional_description: bool = False,
 ) -> str:
     """Generate strings representing sequences in FASTQ format.
 
@@ -247,13 +253,15 @@ def fastq(
     - `min_score`: Lowest quality (PHRED) score to use.
     - `max_score`: Highest quality (PHRED) score to use.
     - `offset`: ASCII encoding offset for quality string.
+    - `add_comment`: Add a comment string after the sequence ID, separated by a space.
+    - `additional_description`: Add sequence ID and comment after `+` on thrid line.
     for more details.
 
     Note:
         See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/ for more details on
         the FASTQ format (and its quality score encoding).
     """
-    header = draw(sequence_id())
+    seq_id = draw(sequence_id())
     sequence = draw(
         dna(
             allow_ambiguous=False,
@@ -263,13 +271,18 @@ def fastq(
             max_size=size,
         )
     )
-    description = ""
+    comment = " " + draw(sequence_id()) if add_comment else ""
     quality = draw(
         fastq_quality(
             size=size, min_score=min_score, max_score=max_score, offset=offset
         )
     )
+    description = seq_id + comment if additional_description else ""
 
-    return "@{header}\n{sequence}\n+{description}\n{quality}".format(
-        header=header, sequence=sequence, description=description, quality=quality
+    return "@{seq_id}{comment}\n{sequence}\n+{description}\n{quality}".format(
+        seq_id=seq_id,
+        sequence=sequence,
+        comment=comment,
+        quality=quality,
+        description=description,
     )

--- a/tests/test_dna.py
+++ b/tests/test_dna.py
@@ -1,5 +1,5 @@
 from hypothesis import given
-from minimal import minimal
+from .minimal import minimal
 
 from hypothesis_bio import dna
 

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,7 +1,7 @@
 from .minimal import minimal
 from hypothesis import errors, given
 import pytest
-from hypothesis_bio.hypothesis_bio import fastq, fastq_quality
+from hypothesis_bio.hypothesis_bio import fastq, fastq_quality, MAX_ASCII
 
 
 def test_fastq_quality_smallest_example():
@@ -77,7 +77,7 @@ def test_fastq_size_over_one(fastq_string: str):
     assert seq_qual_sep == "+"
 
     quality = fields[-1]
-    assert all(64 <= ord(c) <= 126 for c in quality)
+    assert all(64 <= ord(c) <= MAX_ASCII for c in quality)
 
 
 @given(fastq(size=10, add_comment=True))
@@ -97,7 +97,7 @@ def test_fastq_size_over_one_with_comment(fastq_string: str):
     assert seq_qual_sep == "+"
 
     quality = fields[-1]
-    assert all(64 <= ord(c) <= 126 for c in quality)
+    assert all(64 <= ord(c) <= MAX_ASCII for c in quality)
 
 
 @given(fastq(size=10, add_comment=True, additional_description=True))
@@ -121,4 +121,4 @@ def test_fastq_size_over_one_with_comment(fastq_string: str):
     assert " " in header
 
     quality = fields[-1]
-    assert all(64 <= ord(c) <= 126 for c in quality)
+    assert all(64 <= ord(c) <= MAX_ASCII for c in quality)

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,0 +1,54 @@
+from .minimal import minimal
+import hypothesis
+import pytest
+from hypothesis_bio.hypothesis_bio import fastq, fastq_quality
+
+
+def test_fastq_quality_smallest_example():
+    actual = minimal(fastq_quality())
+    expected = ""
+
+    assert actual == expected
+
+
+def test_fastq_quality_smallest_non_empty_with_default_ascii():
+    actual = minimal(fastq_quality(size=1))
+    expected = "@"
+
+    assert actual == expected
+
+
+def test_fastq_quality_size_three_with_one_quality_score():
+    actual = minimal(fastq_quality(size=3, min_score=5, max_score=5))
+    expected = "EEE"
+
+    assert actual == expected
+
+
+def test_fastq_quality_size_three_with_one_quality_score_and_sanger_offset():
+    actual = minimal(fastq_quality(size=3, min_score=5, max_score=5, offset=33))
+    expected = "&&&"
+
+    assert actual == expected
+
+
+def test_fastq_quality_min_score_larger_than_max_score_raises_error():
+    min_score = 10
+    max_score = 9
+    with pytest.raises(hypothesis.errors.InvalidArgument):
+        minimal(fastq_quality(min_score=min_score, max_score=max_score))
+
+
+def test_fastq_quality_offset_causes_outside_ascii_range_raises_error():
+    min_score = 100
+    max_score = 101
+    offset = 200
+    with pytest.raises(ValueError):
+        minimal(fastq_quality(min_score=min_score, max_score=max_score))
+
+
+def test_fastq_smallest_example():
+    actual = minimal(fastq())
+    expected = "@\n\n+\n"
+
+    assert actual == expected

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -49,14 +49,14 @@ def test_fastq_quality_offset_causes_outside_ascii_range_raises_error():
 
 def test_fastq_smallest_example():
     actual = minimal(fastq())
-    expected = "@\n\n+\n"
+    expected = "@ \n\n+ \n"
 
     assert actual == expected
 
 
 def test_fastq_smallest_non_empty():
     actual = minimal(fastq(size=1))
-    expected = "@\nA\n+\n@"
+    expected = "@ \nA\n+ \n@"
 
     assert actual == expected
 
@@ -80,7 +80,7 @@ def test_fastq_size_over_one(fastq_string: str):
     assert all(64 <= ord(c) <= MAX_ASCII for c in quality)
 
 
-@given(fastq(size=10, add_comment=True))
+@given(fastq(size=10, add_comment=True, additional_description=False))
 def test_fastq_size_over_one_with_comment(fastq_string: str):
     fields = fastq_string.split("\n")
     header_begin = fields[0][0]

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -78,3 +78,47 @@ def test_fastq_size_over_one(fastq_string: str):
 
     quality = fields[-1]
     assert all(64 <= ord(c) <= 126 for c in quality)
+
+
+@given(fastq(size=10, add_comment=True))
+def test_fastq_size_over_one_with_comment(fastq_string: str):
+    fields = fastq_string.split("\n")
+    header_begin = fields[0][0]
+    assert header_begin == "@"
+
+    header = fields[0][1:]
+    assert all(c not in ">@" for c in header)
+    assert " " in header
+
+    sequence = fields[1]
+    assert all(c in "ACGT" for c in sequence)
+
+    seq_qual_sep = fields[2][0]
+    assert seq_qual_sep == "+"
+
+    quality = fields[-1]
+    assert all(64 <= ord(c) <= 126 for c in quality)
+
+
+@given(fastq(size=10, add_comment=True, additional_description=True))
+def test_fastq_size_over_one_with_comment(fastq_string: str):
+    fields = fastq_string.split("\n")
+    header_begin = fields[0][0]
+    assert header_begin == "@"
+
+    header = fields[0][1:]
+    assert all(c not in ">@" for c in header)
+    assert " " in header
+
+    sequence = fields[1]
+    assert all(c in "ACGT" for c in sequence)
+
+    seq_qual_sep = fields[2][0]
+    assert seq_qual_sep == "+"
+
+    additional_description = fields[2][1:]
+    assert all(c not in ">@" for c in header)
+    assert " " in header
+
+    quality = fields[-1]
+    assert all(64 <= ord(c) <= 126 for c in quality)

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,5 +1,5 @@
 from .minimal import minimal
-import hypothesis
+from hypothesis import errors, given
 import pytest
 from hypothesis_bio.hypothesis_bio import fastq, fastq_quality
 
@@ -35,7 +35,7 @@ def test_fastq_quality_size_three_with_one_quality_score_and_sanger_offset():
 def test_fastq_quality_min_score_larger_than_max_score_raises_error():
     min_score = 10
     max_score = 9
-    with pytest.raises(hypothesis.errors.InvalidArgument):
+    with pytest.raises(errors.InvalidArgument):
         minimal(fastq_quality(min_score=min_score, max_score=max_score))
 
 
@@ -52,3 +52,29 @@ def test_fastq_smallest_example():
     expected = "@\n\n+\n"
 
     assert actual == expected
+
+
+def test_fastq_smallest_non_empty():
+    actual = minimal(fastq(size=1))
+    expected = "@\nA\n+\n@"
+
+    assert actual == expected
+
+
+@given(fastq(size=10))
+def test_fastq_size_over_one(fastq_string: str):
+    fields = fastq_string.split("\n")
+    header_begin = fields[0][0]
+    assert header_begin == "@"
+
+    header = fields[0][1:]
+    assert all(c not in ">@" for c in header)
+
+    sequence = fields[1]
+    assert all(c in "ACGT" for c in sequence)
+
+    seq_qual_sep = fields[2][0]
+    assert seq_qual_sep == "+"
+
+    quality = fields[-1]
+    assert all(64 <= ord(c) <= 126 for c in quality)

--- a/tests/test_kmers.py
+++ b/tests/test_kmers.py
@@ -1,5 +1,5 @@
 import pytest
-from minimal import minimal
+from .minimal import minimal
 
 from hypothesis_bio import kmers
 

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -1,5 +1,5 @@
 from hypothesis import given
-from minimal import minimal
+from .minimal import minimal
 
 from hypothesis_bio import protein
 


### PR DESCRIPTION
1. Allow for setting min/max quality score range and offset [[see](https://en.wikipedia.org/wiki/FASTQ_format#Encoding)].
2. Update the method for generating fastq strings (i.e not requiring a parsed_fasta).

Add tests for all changes [closes #10 ]