### PR TITLE
Fixes transformation of lowercase 1-char protein to 3-char protein and uses mocking to test

### DIFF
--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -84,7 +84,8 @@ def protein(
     else:
         sequence_3 = ""
         for s in sequence:
-            sequence_3 += protein_1to3[s]
+            s_uppercase = s.upper()
+            sequence_3 += protein_1to3[s_uppercase]
         return sequence_3
 
 

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -57,24 +57,24 @@ def get_unwrapped_function_from_composite_decorator(function):
     return original_function
 
 
-def test_protein__upper_case_protein_is_drawn__get_multi_letter_protein():
+def test_protein__ACD_is_drawn_returns_AlaCysAsp():
     # setup
     draw_mock = Mock(return_value="ACD")
     original_protein = get_unwrapped_function_from_composite_decorator(protein)
 
     # call
-    seq = original_protein(draw_mock, single_letter_protein=False) # the others params do not matter as "ACD" is always drawn regardless of what is passed
+    actual = original_protein(draw_mock, single_letter_protein=False) # the others params do not matter as "ACD" is always drawn regardless of what is passed
 
     # assert
     expected = "AlaCysAsp"
-    assert seq == expected
+    assert actual == expected
 
 
-def test_protein__lower_case_protein_is_drawn__get_multi_letter_protein():
+def test_protein__acd_is_drawn_returns_AlaCysAsp():
     draw_mock = Mock(return_value="acd")
     original_protein = get_unwrapped_function_from_composite_decorator(protein)
 
-    seq = original_protein(draw_mock, single_letter_protein=False)
+    actual = original_protein(draw_mock, single_letter_protein=False)
 
     expected = "AlaCysAsp"
-    assert seq == expected  # fails because utilities.protein_1to3 does not contain lowercase entries
+    assert actual == expected  # fails because utilities.protein_1to3 does not contain lowercase entries

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -1,9 +1,10 @@
+from unittest.mock import Mock
+
 from hypothesis import given
 
 from hypothesis_bio import protein
 
 from .minimal import minimal
-from unittest.mock import Mock
 
 
 @given(protein())
@@ -50,7 +51,8 @@ def test_max_size_3_letter_abbrv():
     assert len(seq) % 3 == 0
 
 
-# unwraps a function wrapped with the @composite decorator - this is horrible, should be refactored
+# unwraps a function wrapped with the @composite decorator
+# TODO: this does not seem good and does not seem portable. Find a better way to unwrap functions out of decorators
 def get_unwrapped_function_from_composite_decorator(function):
     accept_function = function.__wrapped__
     composite_strategy = accept_function()
@@ -59,23 +61,22 @@ def get_unwrapped_function_from_composite_decorator(function):
 
 
 def test_protein__ACD_is_drawn_returns_AlaCysAsp():
-    # setup
     draw_mock = Mock(return_value="ACD")
-    original_protein = get_unwrapped_function_from_composite_decorator(protein)
+    unwrapped_protein = get_unwrapped_function_from_composite_decorator(protein)
 
-    # call
-    actual = original_protein(draw_mock, single_letter_protein=False) # the others params do not matter as "ACD" is always drawn regardless of what is passed
+    actual = unwrapped_protein(
+        draw_mock, single_letter_protein=False
+    )  # the others params do not matter as "ACD" is always drawn regardless of what is passed
 
-    # assert
     expected = "AlaCysAsp"
     assert actual == expected
 
 
 def test_protein__acd_is_drawn_returns_AlaCysAsp():
     draw_mock = Mock(return_value="acd")
-    original_protein = get_unwrapped_function_from_composite_decorator(protein)
+    unwrapped_protein = get_unwrapped_function_from_composite_decorator(protein)
 
-    actual = original_protein(draw_mock, single_letter_protein=False)
+    actual = unwrapped_protein(draw_mock, single_letter_protein=False)
 
     expected = "AlaCysAsp"
-    assert actual == expected  # fails because utilities.protein_1to3 does not contain lowercase entries
+    assert actual == expected


### PR DESCRIPTION
This PR has a small bugfix, but the main content is to show a way of use mocking to remove the randomness of hypothesis' `draw()` function so that we can fix what is drawn, and have deterministic tests, allowing for e.g. to test some corner cases. I am also struggling to know how to do good tests in this project, since this randomness factor seems to complicate things, and we are more interested in the strategy producing output that conforms to certain properties, rather than specific outputs. But mocking in such a way might be helpful to some tests. This is just an example, we could try this to test other parts of this function and other functions.

For full details, see https://github.com/Lab41/hypothesis-bio/issues/36