### PR TITLE
Improve fastq strategy

### DIFF
--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -323,10 +323,11 @@ def fastq(
     draw,
     size=0,
     min_score: int = 0,
-    max_score: int = 62,
-    offset: int = 64,
+    max_score: int = 93,
+    offset: int = 33,
     add_comment: bool = True,
     additional_description: bool = True,
+    wrapped: int = 80,
 ) -> str:
     """Generate strings representing sequences in FASTQ format.
 
@@ -337,9 +338,14 @@ def fastq(
     - `offset`: ASCII encoding offset for quality string.
     - `add_comment`: Add a comment string after the sequence ID, separated by a space.
     - `additional_description`: Add sequence ID and comment after `+` on third line.
+    - `wrapped`: Number of characters to wrap the sequence and quality strings on. Set
+    to 0 to disable wrapping.
 
     Note:
-        See <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/> for more details on
+        The default quality string is 'fastq-sanger' format. If you would like 'fastq-illumina'
+        then set `offset` to 64 and `max_score` to 62. If you would like `fastq-solexa`
+        then set `offset` to 64, `min_score` to -5 and `max_score` to 62.
+        See <https://academic.oup.com/nar/article/38/6/1767/3112533> for more details on
         the FASTQ format (and its quality score encoding).
     """
     seq_id = draw(sequence_id())

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -332,9 +332,9 @@ def sequence_identifier(
 def illumina_sequence_identifier(draw) -> str:
     """Generate an Illumina-style sequence identifier.
 
-
-    Notes:
-        Specifications taken from [here](https://support.illumina.com/help/BaseSpace_Sequence_Hub/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm)
+    ::: tip Note
+    Specifications taken from Specifications taken from [here](https://support.illumina.com/help/BaseSpace_Sequence_Hub/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm)
+    :::
     """
     delim = ":"
     instrument = draw(from_regex(r"[a-zA-Z0-9_]+", fullmatch=True))
@@ -376,9 +376,10 @@ def illumina_sequence_identifier(draw) -> str:
 def nanopore_sequence_identifier(draw) -> str:
     """Generate a Nanopore-style sequence identifier.
 
-    Note:
+    ::: tip Note
         No formal specifications could be found, so am going off a header produced from
         `Guppy` v2.1.3: @db127b21-9336-4052-8a8e-5b5d6ac0e3be runid=700c35056d5bf4191f3f9ade0cb342d8406f8ea4 sampleid=madagascar_tb_mdr_3 read=20199 ch=214 start_time=2018-02-26T21:39:56Z
+    :::
     """
     read_id = draw(
         from_regex(
@@ -418,12 +419,13 @@ def fastq_quality(
     - `max_score`: Highest quality (PHRED) score to use.
     - `offset`: ASCII encoding offset.
 
-    Note:
+    ::: tip Note
         The default quality string is 'fastq-sanger' format. If you would like 'fastq-illumina'
         then set `offset` to 64 and `max_score` to 62. If you would like `fastq-solexa`
         then set `offset` to 64, `min_score` to -5 and `max_score` to 62.
         See <https://academic.oup.com/nar/article/38/6/1767/3112533> for more details on
         the FASTQ format (and its quality score encoding).
+    :::
     """
     min_codepoint = min_score + offset
     max_codepoint = max_score + offset
@@ -473,12 +475,13 @@ def fastq(
     - `wrap_length`: Number of characters to wrap the sequence and quality strings on. Set
     to 0 to disable wrapping.
 
-    Note:
+    ::: tip Note
         The default quality string is 'fastq-sanger' format. If you would like 'fastq-illumina'
         then set `offset` to 64 and `max_score` to 62. If you would like `fastq-solexa`
         then set `offset` to 64, `min_score` to -5 and `max_score` to 62.
         See <https://academic.oup.com/nar/article/38/6/1767/3112533> for more details on
         the FASTQ format (and its quality score encoding).
+    :::
     """
     if identifier_source is None:
         identifier_source = sequence_identifier()

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -262,12 +262,16 @@ def fasta(draw) -> str:
 
 @composite
 def sequence_id(
-    draw, blacklist_characters: Sequence[str] = ">@", max_size: int = 100
+    draw,
+    blacklist_characters: Sequence[str] = "",
+    min_size: int = 1,
+    max_size: int = 100,
 ) -> str:
     """Generates a sequence ID.
 
     Arguments:
     - `blacklist_characters`: Characters to not include in the sequence ID.
+    - `min_size`: Minimum length of the sequence ID.
     - `max_size`: Maximum length of the sequence ID.
     """
     return draw(
@@ -277,6 +281,7 @@ def sequence_id(
                 min_codepoint=33,
                 max_codepoint=MAX_ASCII,
             ),
+            min_size=min_size,
             max_size=max_size,
         )
     )

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -2,6 +2,7 @@
 
 """Main module."""
 
+import textwrap
 from typing import Dict, Optional, Sequence
 
 from hypothesis import assume
@@ -283,7 +284,7 @@ def sequence_id(
 
 @composite
 def fastq_quality(
-    draw, size=0, min_score: int = 0, max_score: int = 62, offset: int = 64
+    draw, size=0, min_score: int = 0, max_score: int = 93, offset: int = 33
 ) -> str:
     """Generates the quality string for the FASTQ format
 
@@ -294,8 +295,11 @@ def fastq_quality(
     - `offset`: ASCII encoding offset.
 
     Note:
-        See <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/> for more details on
-        the quality score encoding.
+        The default quality string is 'fastq-sanger' format. If you would like 'fastq-illumina'
+        then set `offset` to 64 and `max_score` to 62. If you would like `fastq-solexa`
+        then set `offset` to 64, `min_score` to -5 and `max_score` to 62.
+        See <https://academic.oup.com/nar/article/38/6/1767/3112533> for more details on
+        the FASTQ format (and its quality score encoding).
     """
     min_codepoint = min_score + offset
     max_codepoint = max_score + offset
@@ -365,6 +369,10 @@ def fastq(
         )
     )
     description = seq_id + comment if additional_description else ""
+
+    if wrapped > 0:
+        sequence = textwrap.fill(sequence, wrapped)
+        quality = textwrap.fill(quality, wrapped)
 
     return "@{seq_id}{comment}\n{sequence}\n+{description}\n{quality}".format(
         seq_id=seq_id,

--- a/hypothesis_bio/hypothesis_bio.py
+++ b/hypothesis_bio/hypothesis_bio.py
@@ -10,6 +10,7 @@ from hypothesis.searchstrategy import SearchStrategy
 from hypothesis.strategies import (
     characters,
     composite,
+    datetimes,
     from_regex,
     integers,
     sampled_from,
@@ -335,6 +336,40 @@ def illumina_sequence_id(draw) -> str:
         is_filtered=is_filtered,
         control_num=control_num,
         index=index,
+    )
+
+
+@composite
+def nanopore_sequence_id(draw) -> str:
+    """Generate a Nanopore-style sequence identifier.
+
+    Note:
+        No formal specifications could be found, so am going off a header produced from
+        `Guppy` v2.1.3: @db127b21-9336-4052-8a8e-5b5d6ac0e3be runid=700c35056d5bf4191f3f9ade0cb342d8406f8ea4 sampleid=madagascar_tb_mdr_3 read=20199 ch=214 start_time=2018-02-26T21:39:56Z
+    """
+    read_id = draw(
+        from_regex(
+            r"[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}",
+            fullmatch=True,
+        )
+    )
+    run_id = draw(from_regex(r"[a-zA-Z0-9]{40}", fullmatch=True))
+    sample_id = draw(from_regex(r"[!-~]+", fullmatch=True))
+    read_num = draw(integers(min_value=0))
+    channel = draw(integers(min_value=0))
+    date_time = draw(datetimes())
+    start_time = date_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return (
+        "{read_id} runid={run_id} sampleid={sample_id} read={read_num} "
+        "ch={channel} start_time={start_time}"
+    ).format(
+        read_id=read_id,
+        run_id=run_id,
+        sample_id=sample_id,
+        read_num=read_num,
+        channel=channel,
+        start_time=start_time,
     )
 
 

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,7 +1,12 @@
 import pytest
 from hypothesis import errors, given
 
-from hypothesis_bio.hypothesis_bio import MAX_ASCII, fastq, fastq_quality
+from hypothesis_bio.hypothesis_bio import (
+    MAX_ASCII,
+    fastq,
+    fastq_quality,
+    illumina_sequence_id,
+)
 
 from .minimal import minimal
 
@@ -155,3 +160,17 @@ def test_fastq_wrapping_greater_than_size_doesnt_wrap(fastq_string: str):
     expected = 4
 
     assert actual == expected
+
+
+def test_illumina_seq_id_minimal():
+    actual = minimal(illumina_sequence_id())
+    expected = "0:0:0:0:0:0:0:A+A 1:N:0:A"
+
+    assert actual == expected
+
+
+@given(illumina_sequence_id())
+def test_illumina_seq_id_ensure_control_num_is_even_or_zero(seq_id):
+    control_num = int(seq_id.split(":")[-2])
+
+    assert control_num % 2 == 0

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -50,14 +50,14 @@ def test_fastq_quality_offset_causes_outside_ascii_range_raises_error():
 
 def test_fastq_smallest_example():
     actual = minimal(fastq())
-    expected = "@ \n\n+ \n"
+    expected = "@0 0\n\n+0 0\n"
 
     assert actual == expected
 
 
 def test_fastq_smallest_non_empty():
     actual = minimal(fastq(size=1))
-    expected = "@ \nA\n+ \n0"
+    expected = "@0 0\nA\n+0 0\n0"
 
     assert actual == expected
 
@@ -68,8 +68,14 @@ def test_fastq_size_over_one(fastq_string: str):
     header_begin = fields[0][0]
     assert header_begin == "@"
 
-    header = fields[0][1:]
-    assert all(c not in ">@" for c in header)
+    seq_id, comment = fields[0][1:].split()
+    seq_id_opt, comment_opt = fields[2][1:].split()
+    if seq_id:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in seq_id)
+        assert all(33 <= ord(c) <= MAX_ASCII for c in seq_id_opt)
+    if comment:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in comment)
+        assert all(33 <= ord(c) <= MAX_ASCII for c in comment_opt)
 
     sequence = fields[1]
     assert all(c in "ACGT" for c in sequence)
@@ -87,15 +93,20 @@ def test_fastq_size_over_one_with_comment_no_additional_description(fastq_string
     header_begin = fields[0][0]
     assert header_begin == "@"
 
-    header = fields[0][1:]
-    assert all(c not in ">@" for c in header)
-    assert " " in header
+    seq_id, comment = fields[0][1:].split()
+    if seq_id:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in seq_id)
+    if comment:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in comment)
 
     sequence = fields[1]
     assert all(c in "ACGT" for c in sequence)
 
     seq_qual_sep = fields[2][0]
     assert seq_qual_sep == "+"
+
+    optional_description = fields[2][1:].split()
+    assert not optional_description
 
     quality = fields[-1]
     assert all(33 <= ord(c) <= MAX_ASCII for c in quality)
@@ -107,19 +118,20 @@ def test_fastq_size_over_one_with_comment(fastq_string: str):
     header_begin = fields[0][0]
     assert header_begin == "@"
 
-    header = fields[0][1:]
-    assert all(c not in ">@" for c in header)
-    assert " " in header
+    seq_id, comment = fields[0][1:].split()
+    seq_id_opt, comment_opt = fields[2][1:].split()
+    if seq_id:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in seq_id)
+        assert all(33 <= ord(c) <= MAX_ASCII for c in seq_id_opt)
+    if comment:
+        assert all(33 <= ord(c) <= MAX_ASCII for c in comment)
+        assert all(33 <= ord(c) <= MAX_ASCII for c in comment_opt)
 
     sequence = fields[1]
     assert all(c in "ACGT" for c in sequence)
 
     seq_qual_sep = fields[2][0]
     assert seq_qual_sep == "+"
-
-    additional_description = fields[2][1:]
-    assert all(c not in ">@" for c in additional_description)
-    assert " " in header
 
     quality = fields[-1]
     assert all(33 <= ord(c) <= MAX_ASCII for c in quality)

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -6,6 +6,7 @@ from hypothesis_bio.hypothesis_bio import (
     fastq,
     fastq_quality,
     illumina_sequence_id,
+    nanopore_sequence_id,
 )
 
 from .minimal import minimal
@@ -174,3 +175,17 @@ def test_illumina_seq_id_ensure_control_num_is_even_or_zero(seq_id):
     control_num = int(seq_id.split(":")[-2])
 
     assert control_num % 2 == 0
+
+
+def test_nanopore_seq_id_minimal():
+    actual = minimal(nanopore_sequence_id())
+    expected = (
+        "00000000-0000-0000-0000-000000000000 "
+        "runid={} "
+        "sampleid=0 "
+        "read=0 "
+        "ch=0 "
+        "start_time=2000-01-01T00:00:00Z"  # Examples from this strategy shrink towards midnight on January 1st 2000.
+    ).format("0" * 40)
+
+    assert actual == expected


### PR DESCRIPTION
- [x] Allow wrapped sequence and quality strings [closes #16 ]
- [x] Make default quality chars the full readable unicode spectrum ('fastq-sanger`) [closes #37 ]
- [x] Allow to pass sequence source [closes #64 ]

Add functions to generate sequence identifiers for:
- [x]  Illumina
- [x]  Nanopore 
- [ ]  PacBio (can't find any kind of standard format)